### PR TITLE
Init logger before sniffer

### DIFF
--- a/cmd/neigh2route/main.go
+++ b/cmd/neigh2route/main.go
@@ -22,6 +22,7 @@ var (
 
 func main() {
 	flag.Parse()
+	logger.Init(*debugMode)
 
 	if *snifferMode {
 		if *listenInterface == "" {
@@ -29,8 +30,6 @@ func main() {
 		}
 		go sniffer.StartSnifferManager(*listenInterface)
 	}
-
-	logger.Init(*debugMode)
 
 	nm, err := neighbor.NewNeighborManager(*listenInterface)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures logging is initialized immediately after startup flags are parsed, providing accurate log levels from the beginning.
  * Removes duplicate logger initialization to prevent redundant or inconsistent log output.
  * Delivers consistent debug behavior across all modes, including sniffer mode.

* **Chores**
  * Streamlined startup sequence for clearer, more reliable logging without altering public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->